### PR TITLE
Update timeout.conf

### DIFF
--- a/.docker/nginx-proxy/conf.d/timeout.conf
+++ b/.docker/nginx-proxy/conf.d/timeout.conf
@@ -2,3 +2,4 @@ proxy_connect_timeout       3600;
 proxy_send_timeout          3600;
 proxy_read_timeout          3600;
 send_timeout                3600;
+proxy_max_temp_file_size    4096m;

--- a/.docker/nginx-proxy/conf.d/timeout.conf
+++ b/.docker/nginx-proxy/conf.d/timeout.conf
@@ -2,4 +2,5 @@ proxy_connect_timeout       3600;
 proxy_send_timeout          3600;
 proxy_read_timeout          3600;
 send_timeout                3600;
-proxy_max_temp_file_size    4096m;
+# ajusta os chunks para o mesmo tamanho que o nextcloud utiliza
+proxy_max_temp_file_size    10485760m;

--- a/.docker/nginx-proxy/conf.d/timeout.conf
+++ b/.docker/nginx-proxy/conf.d/timeout.conf
@@ -3,4 +3,4 @@ proxy_send_timeout          3600;
 proxy_read_timeout          3600;
 send_timeout                3600;
 # ajusta os chunks para o mesmo tamanho que o nextcloud utiliza
-proxy_max_temp_file_size    10485760m;
+proxy_max_temp_file_size    15360m;


### PR DESCRIPTION
Adiciona variável que cria um arquivo temporário, senão downloads maiores que 2,3GB não são finalizados.

Possívelmente o valor dessa variável pode ser menor, mas, não sei qual métrica utilizar. rs