### PR TITLE
Implement fastcgi_read_timeout

### DIFF
--- a/.docker/web/nextcloud.conf
+++ b/.docker/web/nextcloud.conf
@@ -155,6 +155,7 @@ server {
         fastcgi_request_buffering off;
 
         fastcgi_max_temp_file_size 0;
+        fastcgi_read_timeout 3600;
     }
 
     # Serve static files


### PR DESCRIPTION
Prevent timeout

Changed to: 1 hour
Default value: https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout

The Nextcloud official documentation isn't clear about this related to Nginx:

https://github.com/nextcloud/documentation/blob/a96dfd0c9730da61af29db8a5b0723853585eed5/admin_manual/configuration_files/big_file_upload_configuration.rst#nginx

But suggest 3600 at PHP side:

https://github.com/nextcloud/documentation/blob/a96dfd0c9730da61af29db8a5b0723853585eed5/admin_manual/configuration_files/big_file_upload_configuration.rst#configuring-your-web-server

At PHP side, the default value is -1 that mean as infinite time and we don't need to change at PHP side, only at Nginx side.

## to-do

- [ ] Update all of our instances after merge this PR