### PR TITLE
Support newest version of LibreSign

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -2,6 +2,18 @@ ARG NEXTCLOUD_VERSION=stable-fpm
 
 FROM nextcloud:${NEXTCLOUD_VERSION}
 
+RUN apt-get update \
+    && apt-get install -y \
+        locales \
+        poppler-utils \
+    && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+    && locale-gen \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod uga+x /usr/local/bin/install-php-extensions && sync \
     && install-php-extensions \


### PR DESCRIPTION
New requirements:

- poppler-utils: Necessary to return more metadata about a signature when validate a signed PDF file;
- locales with UTF-8: Necessary to JSignPdf handle accents at text of visible signature stamp.