### PR TITLE
Remove XSS-Protection header from Nginx configs

### DIFF
--- a/.docker/web/nextcloud.conf
+++ b/.docker/web/nextcloud.conf
@@ -67,7 +67,6 @@ server {
     add_header X-Frame-Options                   "SAMEORIGIN"        always;
     add_header X-Permitted-Cross-Domain-Policies "none"              always;
     add_header X-Robots-Tag                      "noindex, nofollow" always;
-    add_header X-XSS-Protection                  "1; mode=block"     always;
 
     # Remove X-Powered-By, which is an information leak
     fastcgi_hide_header X-Powered-By;


### PR DESCRIPTION
Reference: 
`https://github.com/nextcloud/documentation/pull/9188/files`