### PR TITLE
Fix Garage S3 follow-up review feedback

### DIFF
--- a/.docker/garages3.config.php
+++ b/.docker/garages3.config.php
@@ -1,11 +1,12 @@
 <?php
 
 $bucket = getenv('GARAGES3_BUCKET') ?: 'nextcloud';
-$key = getenv('GARAGES3_KEY');
+$key = getenv('GARAGES3_KEY_ID');
+$key = ($key === false || $key === '') ? getenv('GARAGES3_KEY') : $key;
 $secret = getenv('GARAGES3_SECRET');
 
 if ($key === false || $key === '' || $secret === false || $secret === '') {
-    throw new RuntimeException('GARAGES3_KEY and GARAGES3_SECRET must be set for Garage S3 primary storage.');
+    throw new RuntimeException('GARAGES3_KEY_ID (or legacy GARAGES3_KEY) and GARAGES3_SECRET must be set for Garage S3 primary storage.');
 }
 
 $CONFIG = [

--- a/.env.example
+++ b/.env.example
@@ -12,9 +12,12 @@ POSTGRES_PASSWORD=
 NEXTCLOUD_ADMIN_USER=
 NEXTCLOUD_ADMIN_PASSWORD=
 
+# Space-separated trusted domains, for example: "web yourdomain.tld"
 NEXTCLOUD_TRUSTED_DOMAINS=
 
 # Garage S3 primary storage (used by docker-compose-garages3.yml)
+# GARAGES3_KEY is the Garage key name created by scripts/bootstrap-garages3.sh.
+# GARAGES3_KEY_ID is the access key ID consumed by Nextcloud.
 GARAGES3_BUCKET=nextcloud
 GARAGES3_KEY=
 GARAGES3_KEY_ID=

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cp .env.example .env
 | [`VIRTUAL_HOST`](https://github.com/nginx-proxy/nginx-proxy#usage) | `web` | Your domain |
 | [`LETSENCRYPT_HOST`](https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/blob/master/docs/Basic-usage.md#step-3---proxyed-containers) | `web` | Your domain |
 | [`LETSENCRYPT_EMAIL`](https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/blob/master/docs/Let's-Encrypt-and-ACME.md#contact-address) | `web` | Your sysadmin email |
-| `NEXTCLOUD_TRUSTED_DOMAINS` | `app` | domains separated by comma. The domain web is mandatory, add your domain together with whe domain web. The domain `web` is the domain of Nginx service. |
+| `NEXTCLOUD_TRUSTED_DOMAINS` | `app` | space-separated domains. Include the `web` service name and your public domain, for example `web yourdomain.tld`. |
 | `POSTGRES_DB` | `db` | PostgreSQL database name (default: nextcloud) |
 | `POSTGRES_USER` | `db` | PostgreSQL database user (default: nextcloud) |
 | `POSTGRES_PASSWORD` | `db` | PostgreSQL database user password |
@@ -113,8 +113,8 @@ Use `docker-compose-garages3.yml` when you want Nextcloud to store files in a Ga
 The stack expects these values in `.env`:
 
 - `GARAGES3_BUCKET`
-- `GARAGES3_KEY`
-- `GARAGES3_KEY_ID`
+- `GARAGES3_KEY`, the Garage key name created by the bootstrap helper
+- `GARAGES3_KEY_ID`, the Garage access key ID used by Nextcloud
 - `GARAGES3_SECRET`
 - `GARAGES3_HOSTNAME`, defaulting to `host.docker.internal`
 - `GARAGES3_PORT`, defaulting to `3900`

--- a/docs/README_ptBR.md
+++ b/docs/README_ptBR.md
@@ -51,7 +51,7 @@ cp .env.example .env
 | [`VIRTUAL_HOST`](https://github.com/nginx-proxy/nginx-proxy#usage) | `web` | Seu domínio |
 | [`LETSENCRYPT_HOST`](https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/blob/master/docs/Basic-usage.md#step-3---proxyed-containers) | `web` | Seu domínio |
 | [`LETSENCRYPT_EMAIL`](https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/blob/master/docs/Let's-Encrypt-and-ACME.md#contact-address) | `web` | Seu email de administrador de sistema |
-| `NEXTCLOUD_TRUSTED_DOMAINS` | `app` | domínios separados por vírgula. O domínio `web` é obrigatório, adicione seu domínio junto com o domínio `web`. O domínio `web` é o domínio do serviço Nginx. |
+| `NEXTCLOUD_TRUSTED_DOMAINS` | `app` | domínios separados por espaço. Inclua o nome do serviço `web` e seu domínio público, por exemplo `web seudominio.tld`. |
 
 > **PS**: A Let's Encrypt só funciona em servidores quando os `VIRTUAL_HOST` e `LETSENCRYPT_HOST` têm um domínio público válido registrado em um servidor DNS. Não tente usá-lo em localhost, não funciona!
 
@@ -85,8 +85,8 @@ Use `docker-compose-garages3.yml` quando quiser que o Nextcloud grave os arquivo
 O stack espera estes valores em `.env`:
 
 - `GARAGES3_BUCKET`
-- `GARAGES3_KEY`
-- `GARAGES3_KEY_ID`
+- `GARAGES3_KEY`, o nome da chave do Garage criado pelo helper de bootstrap
+- `GARAGES3_KEY_ID`, o access key ID do Garage usado pelo Nextcloud
 - `GARAGES3_SECRET`
 - `GARAGES3_HOSTNAME`, com padrão `host.docker.internal`
 - `GARAGES3_PORT`, com padrão `3900`


### PR DESCRIPTION
This follow-up addresses the actionable review feedback from PR #40.

### What changed
- Read `GARAGES3_KEY_ID` in the Garage S3 config, with `GARAGES3_KEY` kept as a legacy fallback.
- Clarified the Garage env var docs so `GARAGES3_KEY` is described as the key name and `GARAGES3_KEY_ID` as the access key ID used by Nextcloud.
- Fixed the trusted-domains guidance to use space-separated values, matching the Nextcloud container behavior.
- Added matching notes to the example env file in both English and Portuguese docs.

### Why
- The previous config path could start Nextcloud with the wrong Garage credential or fail when only the bootstrap-generated key ID was present.
- The docs were describing trusted domains with the wrong separator.

### Validation
- `php -l .docker/garages3.config.php`
- `git diff --check`
