### PR TITLE
Add Nextcloud 35 development image workflow

### DIFF
--- a/.docker/app/Dockerfile.35
+++ b/.docker/app/Dockerfile.35
@@ -1,0 +1,40 @@
+ARG NEXTCLOUD_BASE_IMAGE=nextcloud:34-fpm
+
+FROM ${NEXTCLOUD_BASE_IMAGE}
+
+ARG NEXTCLOUD_DAILY_URL=https://download.nextcloud.com/server/daily/latest-master.tar.bz2
+
+RUN set -eux; \
+    curl -fsSL "${NEXTCLOUD_DAILY_URL}" -o /tmp/nextcloud.tar.bz2; \
+    curl -fsSL "${NEXTCLOUD_DAILY_URL}.sha512" -o /tmp/nextcloud.tar.bz2.sha512; \
+    cd /tmp; \
+    expected_sha512="$(awk '$2 == "latest-master.tar.bz2" { print $1 }' nextcloud.tar.bz2.sha512)"; \
+    test -n "${expected_sha512}"; \
+    echo "${expected_sha512}  nextcloud.tar.bz2" | sha512sum -c -; \
+    rm -rf /usr/src/nextcloud; \
+    tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    nextcloud_major="$(php -r 'require "/usr/src/nextcloud/version.php"; echo $OC_Version[0];')"; \
+    test "${nextcloud_major}" = 35; \
+    rm -f /tmp/nextcloud.tar.bz2 /tmp/nextcloud.tar.bz2.sha512; \
+    rm -rf /usr/src/nextcloud/updater; \
+    mkdir -p /usr/src/nextcloud/data /usr/src/nextcloud/custom_apps; \
+    chmod +x /usr/src/nextcloud/occ
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        locales \
+        poppler-utils \
+        postgresql-client \
+    && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+    && locale-gen \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync \
+    && install-php-extensions bz2 imagick
+
+COPY config/php.ini /usr/local/etc/php/conf.d/

--- a/.github/workflows/nextcloud-35-development.yml
+++ b/.github/workflows/nextcloud-35-development.yml
@@ -1,0 +1,52 @@
+name: Build Nextcloud 35 Development Image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .docker/app/Dockerfile.35
+      - .docker/app/config/**
+      - .github/workflows/nextcloud-35-development.yml
+
+concurrency:
+  group: nextcloud-35-development
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-app
+
+jobs:
+  build:
+    name: Build and push app:35
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Nextcloud 35 development image
+        uses: docker/build-push-action@v6
+        with:
+          context: .docker/app
+          file: .docker/app/Dockerfile.35
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:35
+          cache-from: type=gha,scope=nextcloud-35-development
+          cache-to: type=gha,mode=max,scope=nextcloud-35-development


### PR DESCRIPTION
## What changed

- adds a dedicated Dockerfile for the Nextcloud 35 development build
- downloads the official `latest-master` daily archive and verifies its SHA-512 checksum
- refuses to build if the archive is no longer major version 35
- includes `postgresql-client`, which provides `pg_dump`
- adds an isolated GitHub Actions workflow that publishes only `ghcr.io/librecodecoop/nextcloud-docker-app:35` for `linux/amd64`

## Why

Nextcloud 35 is still a development release and does not have an official `nextcloud:35-fpm` image. This keeps the development image separate from the existing release workflow and prevents changes to the web image or current tags.

## Validation

- `actionlint .github/workflows/nextcloud-35-development.yml`
- complete BuildKit build for `linux/amd64` with cache-only output
- SHA-512 validation succeeded
- downloaded archive reported major version 35
